### PR TITLE
Fixing environment variables not being set correctly for PHP

### DIFF
--- a/lib/rack/legacy/cgi.rb
+++ b/lib/rack/legacy/cgi.rb
@@ -53,6 +53,7 @@ module Rack
           if io.nil?  # Child
             $stderr.reopen stderr.path
             ENV['DOCUMENT_ROOT'] = public_dir
+            ENV['SERVER_SOFTWARE'] = 'Rack Legacy'
             env.each {|k, v| ENV[k] = v if v.respond_to? :to_str}
             exec *path
           else        # Parent

--- a/lib/rack/legacy/php.rb
+++ b/lib/rack/legacy/php.rb
@@ -33,6 +33,9 @@ module Rack
 
         env['SCRIPT_FILENAME'] = script_path(path)
         env['SCRIPT_NAME'] = script_path(path).sub ::File.expand_path(public_dir), ''
+        env['PATH_INFO'] = info_path(path)
+        env['REQUEST_URI'] = path.sub ::File.expand_path(public_dir), ''
+        env['REQUEST_URI'] += '?' + env['QUERY_STRING'] unless env['QUERY_STRING'].empty?
         super env, @php_exe, *config.flatten
       end
 
@@ -45,6 +48,19 @@ module Rack
       # will return /index.php
       def script_path(path)
         path.split('.php').first + '.php'
+      end
+
+      # Given a full path will extract just the info part. So
+      #
+      #   /index.php/foo/bar
+      #
+      # will return /foo/bar, but
+      #
+      #   /index.php
+      #
+      # will return an empty string.
+      def info_path(path)
+        path.split('.php', 2)[1].to_s
       end
 
       # For processing .htaccess files to tweak PHP environment.


### PR DESCRIPTION
As pointed out by @marzocchi in #2 the PATH_INFO environment variable used to be set to /index.php/foo/bar instead of /foo/bar if the requested url looked like /index.php/foo/bar?param=value.

I also added the REQUEST_URI variable according to the PHP manual (mainly because some applications apparently use it for some routing stuff).

Moreover SERVER_SOFTWARE is now being set to _Rack Legacy_ according to CGI spec (didn't know how to get the current version number added, but I think that doesn't really matter).
