### PR TITLE
Use HTML escaping implementation from rails

### DIFF
--- a/lib/rack/legacy/error_page.rb
+++ b/lib/rack/legacy/error_page.rb
@@ -90,8 +90,8 @@ TEMPLATE
     
       private
     
-      def h(escape)
-        CGI::escapeHTML escape
+      def h(s)
+        s.to_s.gsub(/&/, "&amp;").gsub(/\"/, "&quot;").gsub(/>/, "&gt;").gsub(/</, "&lt;")
       end
     
     end


### PR DESCRIPTION
Use HTML escaping implementation from rails/rails@a19ee5cfd35fe85fd065be30de5af6b20363b682 to avoid errors with non-ASCII strings
