### PR TITLE
Routes to index.php indirectly

### DIFF
--- a/test/functional/php_test.rb
+++ b/test/functional/php_test.rb
@@ -11,6 +11,22 @@ class PhpTest < MiniTest::Unit::TestCase
     assert_match /^PHP/, response.header['x-powered-by']
   end
 
+  def test_index_with_leading_slash
+    response = Mechanize.new.get 'http://localhost:4000/'
+    assert_equal 'PHP index', response.body
+    assert_equal '200', response.code
+    assert_equal 'text/html', response.header['content-type']
+    assert_match /^PHP/, response.header['x-powered-by']
+  end
+
+  def test_index_without_leading_slash
+    response = Mechanize.new.get 'http://localhost:4000'
+    assert_equal 'PHP index', response.body
+    assert_equal '200', response.code
+    assert_equal 'text/html', response.header['content-type']
+    assert_match /^PHP/, response.header['x-powered-by']
+  end
+
   def test_syntax_error
     begin
       Mechanize.new.get 'http://localhost:4000/syntax_error.php'

--- a/test/unit/php_test.rb
+++ b/test/unit/php_test.rb
@@ -19,6 +19,12 @@ class PhpTest < MiniTest::Unit::TestCase
     assert_equal 'text/html', response[1]['Content-type'].first
     assert_match /^PHP/, response[1]['X-Powered-By'].first
 
+    response = app.call 'PATH_INFO' => '/', 'REQUEST_METHOD' => 'GET'
+    assert_equal '200', response.first
+    assert_equal ['PHP index'], response.last
+    assert_equal 'text/html', response[1]['Content-type'].first
+    assert_match /^PHP/, response[1]['X-Powered-By'].first
+
     assert_equal \
       [200, {"Content-Type"=>"text/html"}, ['Endpoint']],
       app.call({'PATH_INFO' => 'missing.php'})


### PR DESCRIPTION
The current version fails to identify a index.php when ommited on the
path. That is, accessing the path `/` might fail while the file
`/index.php` exists. This behavior it is widely used by many applications.
