### PR TITLE
brings this file to Ruby 2.1 standards.

### DIFF
--- a/lib/rack/legacy/index.rb
+++ b/lib/rack/legacy/index.rb
@@ -19,7 +19,7 @@ class Rack::Legacy::Index
     @order.reverse.each do |index|
       full_index = File.join dir, index
       new_path = File.join env['PATH_INFO'], index
-      rewrite = new_path if File.exists? full_index
+      rewrite = new_path if File.exist? full_index
     end if File.directory? dir
     env['PATH_INFO'] = rewrite
     @app.call env


### PR DESCRIPTION
The call File.exists? is [deprecated in 2.1](http://lisp.es/2014/05/05/ruby-2-1-deprecated-file-exists/). Not sure if you plan on updating to Ruby 2.1 or if you are already on it. Just throwing this out there. 
